### PR TITLE
Add a note to login with email, not username

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,9 @@ if (Posts.find().count() === 0) {
 
 Shut down Meteor with `Ctrl+C` and do a `meteor reset` and start it back up again with `meteor`.
 
-Now let's log in **as Sacha** and see what happens. Once logged in, click on the `Accounts` link on the left.
+Now let's log in **as Sacha** (Email: `sacha@example.com` and Password: `123456`) and see what happens. Once logged in, click on the `Accounts` link on the left.
+
+**Important:** to log in to the admin panel you need to type in an **email** address not a **username**.
 
 ![enter image description here](https://lh3.googleusercontent.com/J5K9jjcJU_0KKQVfBcqfXiUNrqcto6slnUyOZ6O1Lks=s0 "Screenshot from 2015-07-23 23:41:12.png")
 


### PR DESCRIPTION
Because I have usernames "saved" to my http://localhost:3000/ I wasn't able to see that the login form was asking for an **email** and **password** - not a **_username**_.

This sent me on a wild goose chase for a while.  So I decided to add a pull request with an appropriate note to help any future travelers like me down this path.

Here are some forum links where this issue is discussed:
http://forums.orionjs.org/t/microscope-example-fails-with-login-forbidden-error/241/3
http://forums.orionjs.org/t/solved-microscope-example-login-forbidden-failure/167

Please consider adding this to the tutorial.  Thanks.
